### PR TITLE
Set sim welcome screen copyright date dynamically

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -825,7 +825,7 @@ addProjectButtons()
 -------------------
 
 
-local copyright1 = newRetinaText("© 2020-2021 Solar2D ", 34, 675, fontSizeCopyright)
+local copyright1 = newRetinaText("© 2020-" .. buildNum:sub(1,4) .. " Solar2D ", 34, 675, fontSizeCopyright)
 copyright1:translate( copyright1.contentWidth*0.5, 0 )
 copyright1:setFillColor( unpack(textColorCopyright) )
 


### PR DESCRIPTION
By using the first four digits of the Solar2D build number instead of a hardcoded date, the copyright text will automatically match the year that particular build was created.

This'll work for all official builds. Locally made builds tend to have a version number of 2100.9999, i.e. they'd show a copyright date of "2020-2100", but I think those are such rare instances and people who're doing those builds won't mind.